### PR TITLE
Add typings to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
   "homepage": "https://sendbird.com",
   "dependencies": {
     "sendbird": "^3.0.55"
-  }
+  },
+  "typings": "SendBird.Desk.d.ts"
 }


### PR DESCRIPTION
This is required for Typescript to work correctly. https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

The non-Desk SDK has this configured correctly:
https://github.com/smilefam/SendBird-SDK-JavaScript/blob/master/package.json#L25