### PR TITLE
Remove line with `status`

### DIFF
--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -1124,7 +1124,7 @@ var Ticket = /** @class */ (function () {
                                 }
                             }
                         });
-                        Logger.write("[REQ] ".concat(status, " ticket list:"), tickets);
+                        Logger.write("[REQ] ticket list:" + tickets);
                         _a.label = 4;
                     case 4: return [2 /*return*/, tickets];
                 }

--- a/dist/esm/index.js
+++ b/dist/esm/index.js
@@ -1124,7 +1124,6 @@ var Ticket = /** @class */ (function () {
                                 }
                             }
                         });
-                        Logger.write("[REQ] ticket list:" + tickets);
                         _a.label = 4;
                     case 4: return [2 /*return*/, tickets];
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sendbird-desk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "SendBird Desk SDK for JavaScript",
   "author": "SendBird",
   "license": "see LICENSE.md",


### PR DESCRIPTION
* The line `Logger.write("[REQ] ".concat(status, " ticket list:"), tickets);` causes a fatal error as `status` is not defined
* Sorry about the weird diff, we may have run a formatter on the file